### PR TITLE
01_재우_서버증설횟수/80/O

### DIFF
--- a/src/week01/jaewoo/ServerAddCountJw.java
+++ b/src/week01/jaewoo/ServerAddCountJw.java
@@ -18,15 +18,14 @@ class Solution {
             }
             // 특정 시간대 유저 수 확인
             int userCount = players[time];
+            int need = userCount / m;
         
             // 서버가 유저를 감당 할 수 없다면 감당할 수 있는 서버 개수로 증설한다.
-            if (userCount >= m && userCount >= currentServerCount * 2 * m) {
-                int requiredServerCount = (userCount / m) - currentServerCount;
+            if (currentServerCount < need) {
+                int requiredServerCount = need - currentServerCount;
                 currentServerCount += requiredServerCount;
                 increaseServerCount += requiredServerCount;
-                servers.put(time, requiredServerCount);
-                System.out.println("증설 시간 : " + time + ", 필요 서버 개수 : " + requiredServerCount + ", 총 증설 개수 : " + increaseServerCount);
-                
+                servers.put(time, requiredServerCount);               
             }
 
         }

--- a/src/week01/jaewoo/ServerAddCountJw.java
+++ b/src/week01/jaewoo/ServerAddCountJw.java
@@ -1,0 +1,35 @@
+import java.util.*;
+
+class Solution {
+    
+    private final Map<Integer, Integer> servers = new HashMap<>();
+    
+    public int solution(int[] players, int m, int k) {
+        // 증설된 서버의 총 개수
+        int increaseServerCount = 0;
+        int currentServerCount = 0;
+        for (int time = 0; time < players.length; time++) {
+            // 증설된 서버가 있다면, k 만큼 지난 후에 제거해야 한다.
+            int expiredTime = time - k;
+            if (expiredTime > 0 && servers.containsKey(expiredTime)) {
+                int expiredServerCount = servers.remove(expiredTime);
+                currentServerCount -= expiredServerCount;
+                System.out.println("삭제 시간 : " + time + ", 삭제된 서버 개수 : " + expiredServerCount + ", 현재 서버 개수 : " + currentServerCount);
+            }
+            // 특정 시간대 유저 수 확인
+            int userCount = players[time];
+        
+            // 서버가 유저를 감당 할 수 없다면 감당할 수 있는 서버 개수로 증설한다.
+            if (userCount >= m && userCount >= currentServerCount * 2 * m) {
+                int requiredServerCount = (userCount / m) - currentServerCount;
+                currentServerCount += requiredServerCount;
+                increaseServerCount += requiredServerCount;
+                servers.put(time, requiredServerCount);
+                System.out.println("증설 시간 : " + time + ", 필요 서버 개수 : " + requiredServerCount + ", 총 증설 개수 : " + increaseServerCount);
+                
+            }
+
+        }
+        return increaseServerCount;
+    }
+}


### PR DESCRIPTION
예제는 통과하는데, 실제 제출하면 틀림. 이유 분석 필요 😿 
<div align="center">
<img width="314" height="500" alt="image" src="https://github.com/user-attachments/assets/9c03ea45-4478-4e12-b4f9-c8c3658d6b57" />

</div>
알고리즘을 모르기 때문에 해결할 수 있는 방법을 생각해보았습니다.

sudo 코드
```text
for 시간 별 유저 수를 확인한다.
  증설된 서버가 있다면, k 만큼 지난 서버는 삭제해야한다.
  특정 시간 대 유저 수를 확인한다.
  만약 서버가 인원수를 감당할 수 없다면
    감당할 수 있도록 서버 개수를 증설한다
    증설된 서버의 개수를 count 한다.  
```

가장 핵심은 `k` 시간 만큼 지난 서버를 삭제해야 한다.

### 내가 생각한 해결 방법
- `Map` 자료 구조에 `Key` 값으로 서버 증설 시간을 저장.
- `Value` 값으로 증설된 서버의 개수를 저장
- 매 번 반복하면서 `expiredTime`을 구한다. (현재 시간 - `k`)
- 만료된 서버를 `Map`에서 제거한다.

<img width="681" height="351" alt="image" src="https://github.com/user-attachments/assets/29127842-936d-49e0-9ef5-bbf7c207bfed" />

### 뭐가 문제일까?
<img width="611" height="383" alt="image" src="https://github.com/user-attachments/assets/9d79203f-37ad-4638-bf40-1c3bc44b78ba" />

필요한 서버의 개수를 잘못 개산했음.

- 더 효과적으로 풀고 쉬운 방법은 없는지?
- 알고리즘을 적용할 수는 없는지?