### PR TITLE
03_재우_석유 시추 /80/X

### DIFF
--- a/src/week02/jaewoo/석유시추.java
+++ b/src/week02/jaewoo/석유시추.java
@@ -1,0 +1,82 @@
+import java.util.*;
+
+class Solution {
+
+    private int[] dx = {0, 0, -1, 1};
+    private int[] dy = {-1, 1, 0, 0};
+    private int n;
+    private int m;
+
+    public int solution(int[][] land) {
+        n = land.length;
+        m = land[0].length;
+        
+        int[][] oilIdMap = new int[n][m];
+        Map<Integer, Integer> oilAmount = new HashMap<>();
+        boolean[][] visited = new boolean[n][m];
+        
+        int id = 1;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (land[i][j] == 1 && !visited[i][j]) {
+                    int amount = bfs(land, visited, i, j, oilIdMap, id);
+                    oilAmount.put(id, amount);
+                    id++;
+                }
+            }
+        }
+        
+        int maxOil = 0;
+        for (int col = 0; col < m; col++) {
+            Set<Integer> ids = new HashSet<>();
+            for (int row = 0; row < n; row++) {
+                if (oilIdMap[row][col] != 0) {
+                    ids.add(oilIdMap[row][col]);
+                }
+            }
+            int sum = 0;
+            for (int target : ids) {
+                sum += oilAmount.get(target);
+            }
+            maxOil = Math.max(maxOil, sum);
+        }
+        
+        return maxOil;
+    }
+    
+    private int bfs(
+        int[][] land, 
+        boolean[][] visited, 
+        int row, int col,
+        int[][] oilMap,
+        int id
+    ) {
+        Queue<int[]> q = new LinkedList<>();
+        q.add(new int[]{row, col});
+        visited[row][col] = true;
+        oilMap[row][col] = id;
+        
+        int count = 1;
+        
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            int r = cur[0];
+            int c = cur[1];
+            
+            for (int i = 0; i < 4; i++) {
+                int nr = r + dx[i];
+                int nc = c + dy[i];
+                
+                if (nr < 0 || nr >= n || nc < 0 || nc >= m) continue;
+                if (visited[nr][nc]) continue; 
+                if (land[nr][nc] == 0) continue;
+                
+                visited[nr][nc] = true;
+                oilMap[nr][nc] = id;
+                q.add(new int[]{nr, nc});
+                count++;
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
# 석유 시추

[프로그래머스](https://school.programmers.co.kr/learn/courses/30/lessons/250136#)

### 주어진 석유 Map
```text
[
  [1, 0, 1, 0, 1, 1],
  [1, 0, 1, 0, 0, 0],
  [1, 0, 1, 0, 0, 1],
  [1, 0, 0, 1, 0, 0],
  [1, 0, 0, 1, 0, 1],
  [1, 0, 0, 0, 0, 0],
  [1, 1, 1, 1, 1, 1]
]
```
시추관이 열(col) 을 관통해서 지나가는 석유칸을 모두 시추할 수 있다.

즉, 첫 열에 시추관을 꽂는다면
```text
      ↓
     [1, 0, 1, 0, 1, 1],
     [1, 0, 1, 0, 0, 0],
     [1, 0, 1, 0, 0, 1],
     [1, 0, 0, 1, 0, 0],
     [1, 0, 0, 1, 0, 1],
     [1, 0, 0, 0, 0, 0],
→    [1, 1, 1, 1, 1, 1]
```
총 12개 칸의 석유를 뽑아낸다. 

마지막의 열에 시추관을 꽂는다면
석유가 있는 칸에 연결된 석유 모두를 시추할 수 있으므로 총 16 칸의 석유를 뽑아낼 수 있다.

# 해결 방법
1. **중복이 많아져 효율성이 떨어지는 방법**

- 열의 크기만큼 탐색을 반복한다. 
- 즉 0열 부터 m 열 까지 반복하며 연결된 석유의 개수를 센다.

- 첫 열에 연결된 석유를 각각 탐색하고 나온 값을 모두 더한다.
```java
int n = land.length;      // 행의 길이
int m = land[0].length;  // 열의 길이

int maxOil= 0;
for (int col = 0; col < m; col++) {  // 2차 반복문에서 열을 먼저 반복한다.
  boolean[][] visited = new boolean[n][m];
  int amount = 0; 
  for (int row = 0; row < n; row++) {
    if (석유가 있다 && 방문하지 않았다) {
      amount += bfs();  // 탐색을 통해서 방문 체크와 해당 n,m 인덱스에 연결된 석유의 개수를 반환한다.
    }
  }
  maxOil = Math.max(maxOil, amount);
}
```
제한으로 주어진 행과 열의 크기는 `0 < length < 501`
가장 최악의 상황으로 500개의 열이 주어졌을 때 500열을 반복해서 탐색한다.

2. **미리 석유가 존재하는 칸을 그룹해서 탐색 횟수를 1번으로 줄인다.**

- 연결된 석유들을 그룹핑해서 특정 그룹의 석유 개수를 미리 구해 재사용한다.
예를 들어서 

```text
[
  [1, 0, 1, 0, 1, 1],
  [1, 0, 1, 0, 0, 0],
  [1, 0, 1, 0, 0, 1],
  [1, 0, 0, 1, 0, 0],
  [1, 0, 0, 1, 0, 1],
  [1, 0, 0, 0, 0, 0],
  [1, 1, 1, 1, 1, 1]
]
```
첫 0행 0열의 연결된 석유의 개수는 총 12개 이다.
이를 고유한 id로 그룹핑한다. 그룹의 연결된 석유의 개수를 구한다.
```text
{ 
  {id : 1, value : 12},
  {id : 2, value : 3},
  {id : 3, value : 2},
  {id : 4, value : 2},
  {id : 5, value : 1},
  {id : 6, value : 1}
}
```

이제 기존의 석유의 여부를 저장했던 `land` 배열 처럼 각 석유의 id값을 저장하고 있는 배열을 만든다.
```text
// 그룹핑 해서 연결된 석유는 같은 id를 가진다.
[
  [1, 0, 2, 0, 3, 3],
  [1, 0, 2, 0, 0, 0],
  [1, 0, 2, 0, 0, 5],
  [1, 0, 0, 4, 0, 0],
  [1, 0, 0, 4, 0, 6],
  [1, 0, 0, 0, 0, 0],
  [1, 1, 1, 1, 1, 1]
]
```
이렇게 저장한 id 배열을 열에 시추관을 꽂아서 가장 많은 석유를 뽑을 수 있는 index를 구하면된다.
똑같은 id 는 반복해서 더하지 않도록 `Set` 자료 구조를 이용해서 해당 열에 존재하는 id의 값을 담는다.
담은 id의 석유 개수를 더해 가장 많은 석유를 뽑을 수 있는 열을 구한다.

```
Map<Integer, Integer> OilIdMap = new HashMap<>();  // id가 가진 석유의 개수를 저장하는 자료 구조

for (int col = 0; col < m; col++) {
  Set<Integer> ids = new HashSet<>();
  for (int row = 0; row < n; row++) {
    if (!land[row][col] == 0) {
      ids.add(oilMap[row][col]);
    }
  }
  int sum = 0;
  for (int id : ids) {
    sum += oilIdMap.get(id);
  }
  maxOilAmount = Math.max(maxOilAmount, sum);
}
``` 
